### PR TITLE
Manifest fix

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include django_ilmoitin/static *
+recursive-include django_ilmoitin/templates *

--- a/django_ilmoitin/__init__.py
+++ b/django_ilmoitin/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = "django_ilmoitin.apps.DjangoIlmoitinConfig"
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     license="MIT License",
     description="Django app for sending notifications.",
     long_description=README,
+    long_description_content_type="text/markdown",
     url="https://github.com/City-of-Helsinki/django-ilmoitin",
     author="City of Helsinki",
     author_email="dev@hel.fi",


### PR DESCRIPTION
- Templates where missing from manifest
- Pypi was complaining about missing long description content type