### PR TITLE
Limit django-parler version to be lower than 2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author_email="dev@hel.fi",
     install_requires=[
         "Django",
-        "django-parler",
+        "django-parler<2.0",
         "django-anymail",
         "django-mailer",
         "jinja2",


### PR DESCRIPTION
Django-parler 2.0 requires at least a new migration to be added.