### PR TITLE
Namespace dummy context

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A templated Django messaging library
 
     ```python
     python manage.py migrate ilmoitin
+    ```
 
 # Usage
 
@@ -39,19 +40,28 @@ send the mail:
     from django_ilmoitin.registry import notifications
     
     notifications.register("event_created", "Event created")
+    notifications.register("event_deleted", "Event deleted")
     ```
 
-4. Create a `dummy_context.py` file in django app and add dummy context data:
+4. Create a `dummy_context.py` file in django app and add dummy context data.
+Either use the codes of notifications that you registered in the previous step, or
+use the const `COMMON_CONTEXT` to make some variables available for all templates:
 
     ```python
-    from django_ilmoitin.dummy_context import dummy_context
+    from django_ilmoitin.dummy_context import COMMON_CONTEXT, dummy_context
     
     from .models import MyModel
     
-    model = MyModel(foo="bar")
+    my_object = MyModel(foo="bar")
     
-    dummy_context.context.update({
-        "model": model
+    dummy_context.update({
+        COMMON_CONTEXT: {"my_object": my_object},
+        "event_created": {
+            "foo": "bar"
+        },
+        "event_deleted": {
+            "fizz": "buzz"
+        }
     })
     ```
 

--- a/django_ilmoitin/admin.py
+++ b/django_ilmoitin/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from django.db.models import Q
 from django.http import HttpResponse
 from django.utils.translation import ugettext_lazy as _
-from jinja2 import DebugUndefined, TemplateSyntaxError
+from jinja2 import DebugUndefined, TemplateError
 from jinja2.sandbox import SandboxedEnvironment
 from parler.admin import TranslatableAdmin
 from parler.forms import TranslatableModelForm
@@ -79,7 +79,7 @@ class NotificationTemplateAdmin(TranslatableAdmin):
         try:
             body_html = env.from_string(obj.body_html).render(dummy_context.context)
             return HttpResponse(body_html)
-        except TemplateSyntaxError as e:
+        except TemplateError as e:
             return HttpResponse(e)
 
 

--- a/django_ilmoitin/admin.py
+++ b/django_ilmoitin/admin.py
@@ -77,7 +77,9 @@ class NotificationTemplateAdmin(TranslatableAdmin):
             trim_blocks=True, lstrip_blocks=True, undefined=DebugUndefined
         )
         try:
-            body_html = env.from_string(obj.body_html).render(dummy_context.context)
+            body_html = env.from_string(obj.body_html).render(
+                dummy_context.get(obj.type)
+            )
             return HttpResponse(body_html)
         except TemplateError as e:
             return HttpResponse(e)

--- a/django_ilmoitin/dummy_context.py
+++ b/django_ilmoitin/dummy_context.py
@@ -1,5 +1,70 @@
+from collections import defaultdict
+from copy import deepcopy
+from enum import Enum
+from typing import Any, Mapping, Type, Union
+
+from .registry import notifications
+
+_StrOrEnum = Union[str, Type[Enum]]
+
+COMMON_CONTEXT = "__common__"
+
+
 class DummyContext:
-    context = {}
+    context = defaultdict(dict)
+
+    def update(self, context_dict: Mapping[_StrOrEnum, Mapping[str, Any]]) -> None:
+        """
+        Proxy helper method that makes updating
+        DummyContext's context storage less verbose.
+
+        :param context_dict: dictionary of values to be put into dummy context
+        """
+        assert isinstance(
+            context_dict, Mapping
+        ), "DummyContext's update() method accepts only dictionaries."
+
+        for type_code, context in context_dict.items():
+            if isinstance(type_code, Enum):
+                type_code = type_code.value
+
+            self._assert_type_code_is_str(type_code)
+            if not type_code == COMMON_CONTEXT:
+                self._assert_notification_type_exists(type_code)
+
+            self.context.update({type_code: context})
+
+    def get(self, type_code: _StrOrEnum) -> dict:
+        """
+        Proxy helper method that makes fetching from
+        DummyContext's context storage less verbose.
+
+        :param type_code: code of the notification type
+        :return: dummy context for the notification type
+        """
+        if isinstance(type_code, Enum):
+            type_code = type_code.value
+
+        self._assert_type_code_is_str(type_code)
+        self._assert_notification_type_exists(type_code)
+
+        context = deepcopy(self.context.get(COMMON_CONTEXT)) or {}
+        context.update(self.context.get(type_code, {}))
+        return context
+
+    @staticmethod
+    def _assert_type_code_is_str(type_code: str) -> None:
+        assert isinstance(type_code, str), (
+            "Expected a string code for a notification"
+            "template's type, received {}".format(type(type_code))
+        )
+
+    @staticmethod
+    def _assert_notification_type_exists(type_code: str) -> None:
+        assert type_code in notifications.registry, (
+            "This type of notification is not"
+            "registered with the ilmoitin: {}".format(type_code)
+        )
 
 
 dummy_context = DummyContext()

--- a/django_ilmoitin/models.py
+++ b/django_ilmoitin/models.py
@@ -65,6 +65,6 @@ class NotificationTemplate(TranslatableModel):
 
     def __str__(self):
         if self.type in notifications.registry:
-            return notifications.registry[self.type]
+            return str(notifications.registry[self.type])
         else:
             return "{} ({})".format(self.type, _("disabled"))

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,10 @@ DJANGO_SETTINGS_MODULE = tests.settings
 norecursedirs = bower_components node_modules .git .idea test_app
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ALLOW_UNICODE 
 
+[coverage:run]
+branch = True
+omit = *migrations*,*site-packages*,*venv*,*tests*
+
 [isort]
 known_first_party=django_ilmoitin
 default_section = THIRDPARTY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+
+from django_ilmoitin.models import NotificationTemplate
+from django_ilmoitin.registry import notifications
+
+
+@pytest.fixture(autouse=True)
+def autouse_django_db(db):
+    pass
+
+
+@pytest.fixture
+def notification_template(settings):
+    settings.LANGUAGES = (("fi", "Finnish"), ("en", "English"))
+    notifications.register("event_created", "Event created")
+    notifications.register("event_approved", "Event approved")
+    template = NotificationTemplate.objects.language("en").create(
+        type="event_created",
+        subject="test subject, variable value: {{ subject_var }}!",
+        body_html="<b>test body HTML</b>, variable value: {{ body_html_var }}!",
+        body_text="test body text, variable value: {{ body_text_var }}!",
+    )
+    template.set_current_language("fi")
+    template.subject = "testiotsikko, muuttujan arvo: {{ subject_var }}!"
+    template.body_html = (
+        "<b>testihötömölöruumis</b>, muuttujan arvo: {{ body_html_var }}!"
+    )
+    template.body_text = "testitekstiruumis, muuttujan arvo: {{ body_text_var }}!"
+
+    template.save()
+
+    return template

--- a/tests/test_dummy_context.py
+++ b/tests/test_dummy_context.py
@@ -1,0 +1,59 @@
+from enum import Enum
+
+import pytest
+
+from django_ilmoitin.dummy_context import COMMON_CONTEXT, DummyContext
+from django_ilmoitin.registry import notifications
+
+
+def test_dummy_context_update_accepts_only_dicts():
+    dummy_context = DummyContext()
+
+    with pytest.raises(AssertionError):
+        dummy_context.update("string")
+
+
+def test_dummy_context_allows_only_registered_notification_types():
+    dummy_context = DummyContext()
+
+    with pytest.raises(AssertionError):
+        dummy_context.update(
+            {COMMON_CONTEXT: {"key": "value"}, "my_notification": {"key2": "value2"}}
+        )
+
+
+def test_dummy_context_allows_only_strings_as_keys_for_contexts():
+    dummy_context = DummyContext()
+
+    with pytest.raises(AssertionError):
+        dummy_context.update(
+            {COMMON_CONTEXT: {"key": "value"}, 777: {"key2": "value2"}}
+        )
+
+
+def test_dummy_context_builds_correctly():
+    notifications.register("my_notification", "My notification")
+
+    dummy_context = DummyContext()
+    dummy_context.update(
+        {COMMON_CONTEXT: {"key": "value"}, "my_notification": {"key2": "value2"}}
+    )
+    assert dummy_context.get("my_notification") == {"key": "value", "key2": "value2"}
+
+    notifications.registry.clear()
+
+
+def test_dummy_context_handles_enums():
+    class MyEnum(Enum):
+        FOO = "foo"
+
+    notifications.register(MyEnum.FOO.value, "My enum foo")
+
+    dummy_context = DummyContext()
+    dummy_context.update(
+        {COMMON_CONTEXT: {"key": "value"}, MyEnum.FOO: {"key2": "value2"}}
+    )
+
+    assert dummy_context.get(MyEnum.FOO) == {"key": "value", "key2": "value2"}
+
+    notifications.registry.clear()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -3,34 +3,9 @@ from django.conf import settings
 from django.core import mail
 
 from django_ilmoitin.models import NotificationTemplate, NotificationTemplateException
-from django_ilmoitin.registry import notifications
 from django_ilmoitin.utils import render_notification_template, send_notification
 
 
-@pytest.fixture
-def notification_template(settings):
-    settings.LANGUAGES = (("fi", "Finnish"), ("en", "English"))
-    notifications.register("event_created", "Event created")
-    notifications.register("event_approved", "Event approved")
-    template = NotificationTemplate.objects.language("en").create(
-        type="event_created",
-        subject="test subject, variable value: {{ subject_var }}!",
-        body_html="<b>test body HTML</b>, variable value: {{ body_html_var }}!",
-        body_text="test body text, variable value: {{ body_text_var }}!",
-    )
-    template.set_current_language("fi")
-    template.subject = "testiotsikko, muuttujan arvo: {{ subject_var }}!"
-    template.body_html = (
-        "<b>testihötömölöruumis</b>, muuttujan arvo: {{ body_html_var }}!"
-    )
-    template.body_text = "testitekstiruumis, muuttujan arvo: {{ body_text_var }}!"
-
-    template.save()
-
-    return template
-
-
-@pytest.mark.django_db
 def test_notification_template_rendering(notification_template):
     context = {
         "extra_var": "foo",
@@ -54,7 +29,6 @@ def test_notification_template_rendering(notification_template):
     assert rendered.body_text == "testitekstiruumis, muuttujan arvo: text_baz!"
 
 
-@pytest.mark.django_db
 def test_notification_template_rendering_no_body_text_provided(notification_template):
     context = {
         "extra_var": "foo",
@@ -84,7 +58,6 @@ def test_notification_template_rendering_no_body_text_provided(notification_temp
     assert rendered.body_text == "testihötömölöruumis, muuttujan arvo: html_baz!"
 
 
-@pytest.mark.django_db
 def test_undefined_rendering_context_variable(notification_template):
     context = {"extra_var": "foo", "subject_var": "bar", "body_text_var": "baz"}
 
@@ -95,7 +68,6 @@ def test_undefined_rendering_context_variable(notification_template):
     assert "'body_html_var' is undefined" in str(e.value)
 
 
-@pytest.mark.django_db
 def test_notification_sending(notification_template):
     context = {
         "extra_var": "foo",


### PR DESCRIPTION
1. Ensure string in templates' __str__ methods
2. Catch all jinja errors in preview
3. Refactor DummyContext functionality