### PR TITLE
Add support to send delayed notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ use the const `COMMON_CONTEXT` to make some variables available for all template
     send_notification("foo@bar.com", "event_created", context)
     
     ```
+   
+8. By default, notifications will be sent immediately, if you only want to add notification to the message queue
+ and send it later, configure `ILMOITIN_QUEUE_NOTIFICATIONS`:
+    ```python
+    ILMOITIN_QUEUE_NOTIFICATIONS = True
+    ```
 
 ## Code format
 

--- a/django_ilmoitin/utils.py
+++ b/django_ilmoitin/utils.py
@@ -81,9 +81,10 @@ def send_notification(
         for admin in template.admins_to_notify.all():
             send_mail(admin_subject, admin_text, admin.email, from_email=from_email)
 
-    # also immediately fire django-mailer's commands
-    Message.objects.retry_deferred()
-    send_all()
+    # Immediately fire django-mailer's commands if delayed=False
+    if not getattr(settings, "ILMOITIN_QUEUE_NOTIFICATIONS", False):
+        Message.objects.retry_deferred()
+        send_all()
 
 
 def render_notification_template(template, context, language_code=DEFAULT_LANGUAGE):


### PR DESCRIPTION
Some application needs to send massive notifications at the same time. Currently, there is no support to send notification asynchronously as each notification will be sent immediately when calling `send_notification`.
Added a `delayed` flag (default is `False`), so if `delayed` is `True` the message will be kept in the DB and will be sent later from the app