### PR TITLE
Changed the way how user model relation is defined is models

### DIFF
--- a/django_ilmoitin/models.py
+++ b/django_ilmoitin/models.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from parler.models import TranslatableModel, TranslatedFields
@@ -18,7 +18,7 @@ class NotificationTemplate(TranslatableModel):
     type = models.CharField(max_length=50, verbose_name=_("type"), unique=True)
 
     admins_to_notify = models.ManyToManyField(
-        get_user_model(),
+        settings.AUTH_USER_MODEL,
         related_name="+",
         blank=True,
         verbose_name=_("Admins to notify"),


### PR DESCRIPTION
Using `get_user_model()`-function in relations to user model can cause circular import problems. I encountered this problem while integrating ilmoitin to Respa. Changed `get_user_model()` to `settings.AUTH_USER_MODEL` to prevent problems. 

Also in Django docs:

![image](https://user-images.githubusercontent.com/56429082/75672698-f215a080-5c89-11ea-835e-555150af1405.png)
