### PR TITLE
Email attachments can now be passed to send_notification function

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ use the const `COMMON_CONTEXT` to make some variables available for all template
 
 6. Go to django admin and add notification templates to your notifications
 
-7. Send notifications:
+7. Send notifications. List of attachment files can be passed as last optional argument:
 
     ```python
     from django_ilmoitin.utils import send_notification
@@ -97,7 +97,9 @@ use the const `COMMON_CONTEXT` to make some variables available for all template
     context = {
         "foo": "bar",
     }
-    send_notification("foo@bar.com", "event_created", context)
+    attachment = "test.txt", "foo bar", "text/plain"
+
+    send_notification("foo@bar.com", "event_created", context, [attachment])
     
     ```
    

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -77,7 +77,10 @@ def test_notification_sending(notification_template):
         "body_html_var": "html_baz",
         "body_text_var": "text_baz",
     }
-    send_notification("foo@bar.fi", "event_created", context, "fi")
+
+    attachment = "test.txt", "foo bar", "text/plain"
+
+    send_notification("foo@bar.fi", "event_created", context, "fi", [attachment])
 
     assert len(mail.outbox) == 1
     message = mail.outbox[0]
@@ -90,6 +93,7 @@ def test_notification_sending(notification_template):
     assert subject == "testiotsikko, muuttujan arvo: bar!"
     assert body_html == "<b>testihötömölöruumis</b>, muuttujan arvo: html_baz!"
     assert body_text == "testitekstiruumis, muuttujan arvo: text_baz!"
+    assert message.attachments[0] == attachment
 
 
 @pytest.mark.parametrize("language", ["fi", "en"])


### PR DESCRIPTION
Added support to add attachment files to email notifications. This feature is used in Respa to send `.ical` calendar files with reservation confirmations and we are currently integrating ilmoitin to Respa.