### PR TITLE
[Hotfix] Explicit GraphQL resolver

### DIFF
--- a/django_ilmoitin/__init__.py
+++ b/django_ilmoitin/__init__.py
@@ -1,3 +1,3 @@
 default_app_config = "django_ilmoitin.apps.DjangoIlmoitinConfig"
 
-__version__ = "0.5.1"
+__version__ = "0.5.2"

--- a/django_ilmoitin/api/schema/queries.py
+++ b/django_ilmoitin/api/schema/queries.py
@@ -1,7 +1,13 @@
 from graphene_django import DjangoConnectionField
 
+from django_ilmoitin.models import NotificationTemplate
+
 from .types import NotificationTemplateNode
 
 
 class Query:
     notification_templates = DjangoConnectionField(NotificationTemplateNode)
+
+    @staticmethod
+    def resolve_notification_templates(parent, info, **kwargs):
+        return NotificationTemplate.objects.all()


### PR DESCRIPTION
## Description :sparkles:
To be able to add authentication for the queries, we needed to have the resolver explicitly declared on the `Query` class so we could use it later on the protected resolver.

The behaviour on the `ilmoitin`-level is exactly the same.

With the explicit resolvers, you can later add permission checking like this on your main `Query` class:
```python
@staticmethod
@view_permission_required(NotificationTemplate)
def resolve_notification_templates(parent, info, **kwargs):
    return django_ilmoitin_schema.Query.resolve_notification_templates(
        parent, info, **kwargs
    )
```

This PR also bumps the `__version__` on the package code to the latest version (`0.5.2` after this PR is merged)

## Issues :bug:
### Rlated :handshake:
**[VEN-674](https://helsinkisolutionoffice.atlassian.net/browse/VEN-674):** Existing notification templates could be queried via GQL API

## Testing :alembic:
### Automated tests :gear:️
```shell
$ pytest tests/test_notification_queries.py
```