### PR TITLE
Prefix Language enum with model name

### DIFF
--- a/django_ilmoitin/api/schema/types.py
+++ b/django_ilmoitin/api/schema/types.py
@@ -8,7 +8,8 @@ from django_ilmoitin.models import NotificationTemplate
 from django_ilmoitin.utils import render_preview
 
 LanguageEnum = graphene.Enum(
-    "Language", [(lang[0].upper(), lang[0]) for lang in settings.LANGUAGES]
+    "NotificationTemplateLanguage",
+    [(lang[0].upper(), lang[0]) for lang in settings.LANGUAGES],
 )
 
 


### PR DESCRIPTION
Without the prefix the Enum might clash with other `Language` enums
in the project, if they have different enum values.